### PR TITLE
Update vault sidecar to 0.6.2

### DIFF
--- a/base/vault-sidecar-aws-base.yaml
+++ b/base/vault-sidecar-aws-base.yaml
@@ -2,7 +2,7 @@ name: vault-sidecar-aws-base
 prependContainers: true
 containers:
   - name: vault-credentials-agent
-    image: quay.io/utilitywarehouse/vault-kube-cloud-credentials:0.6.0
+    image: quay.io/utilitywarehouse/vault-kube-cloud-credentials:0.6.2
     lifecycle:
       postStart:
         exec:

--- a/base/vault-sidecar-aws-gcp-base.yaml
+++ b/base/vault-sidecar-aws-gcp-base.yaml
@@ -2,7 +2,7 @@ name: vault-sidecar-aws-gcp-base
 prependContainers: true
 containers:
   - name: vault-credentials-agent-aws
-    image: quay.io/utilitywarehouse/vault-kube-cloud-credentials:0.6.0
+    image: quay.io/utilitywarehouse/vault-kube-cloud-credentials:0.6.2
     lifecycle:
       postStart:
         exec:
@@ -27,7 +27,7 @@ containers:
       - name: vault-tls
         mountPath: /etc/tls
   - name: vault-credentials-agent-gcp
-    image: quay.io/utilitywarehouse/vault-kube-cloud-credentials:0.6.0
+    image: quay.io/utilitywarehouse/vault-kube-cloud-credentials:0.6.2
     lifecycle:
       postStart:
         exec:

--- a/base/vault-sidecar-gcp-base.yaml
+++ b/base/vault-sidecar-gcp-base.yaml
@@ -2,7 +2,7 @@ name: vault-sidecar-gcp-base
 prependContainers: true
 containers:
   - name: vault-credentials-agent
-    image: quay.io/utilitywarehouse/vault-kube-cloud-credentials:0.6.0
+    image: quay.io/utilitywarehouse/vault-kube-cloud-credentials:0.6.2
     lifecycle:
       postStart:
         exec:


### PR DESCRIPTION
This fixes an issue where the sidecar could exhaust CPU if credentials weren't retrieved immediately on startup.